### PR TITLE
Remove github link from header

### DIFF
--- a/source/_header.erb
+++ b/source/_header.erb
@@ -28,11 +28,6 @@
       </form>
       <div id="st-results-container"></div>
     </li>
-    <li>
-        <div id="github">
-          <a href="https://github.com/emberjs/ember.js"><i class="icon-fork"></i>Fork Us!</a>
-        </div>
-    </li>
   </ul>
 </header>
 


### PR DESCRIPTION
As @locks requested at https://github.com/emberjs/guides/pull/947.